### PR TITLE
 feat: swap to negativo17 as nvidia driver source, again

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -142,7 +142,7 @@ jobs:
         id: meta
         with:
           images: |
-            ${{ env.IMAGE_NAME) }}
+            ${{ env.IMAGE_NAME }}
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_BASE_NAME }}
             org.opencontainers.image.description=A caching layer for pre-built akmod RPMs
@@ -168,7 +168,7 @@ jobs:
         with:
           containerfiles: |
             ./Containerfile.${{ matrix.cfile_suffix }}
-          image: ${{ env.IMAGE_NAME) }}
+          image: ${{ env.IMAGE_NAME }}
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
 env:
-    IMAGE_NAME: akmods
+    IMAGE_BASE_NAME: akmods
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 concurrency:
@@ -35,14 +35,7 @@ jobs:
         cfile_suffix:
           - common
           - nvidia
-        nvidia_version:
-          - 0
-          - 550
         exclude:
-          - cfile_suffix: common
-            nvidia_version: 550
-          - cfile_suffix: nvidia
-            nvidia_version: 0
           - kernel_flavor: asus
             fedora_version: 38
           - kernel_flavor: surface
@@ -68,6 +61,11 @@ jobs:
               echo "SOURCE_IMAGE=base" >> $GITHUB_ENV
               echo "SOURCE_ORG=fedora-ostree-desktops" >> $GITHUB_ENV
           fi
+          if [ "common" == "${{ matrix.cfile_suffix }}" ]; then
+              echo "IMAGE_NAME=${{ env.IMAGE_BASE_NAME }}" >> $GITHUB_ENV
+          else
+              echo "IMAGE_NAME=${{ env.IMAGE_BASE_NAME }}-${{ matrix.cfile_suffix }}" >> $GITHUB_ENV
+          fi
 
       - name: Generate tags
         id: generate-tags
@@ -75,11 +73,7 @@ jobs:
         run: |
           # Generate a timestamp for creating an image version history
           TIMESTAMP="$(date +%Y%m%d)"
-          if [[ "${{ matrix.cfile_suffix }}" == "nvidia" ]]; then
-              VARIANT="${{ matrix.kernel_flavor }}-${{ matrix.fedora_version }}-${{ matrix.nvidia_version }}"
-          else
-              VARIANT="${{ matrix.kernel_flavor }}-${{ matrix.fedora_version }}"
-          fi
+          VARIANT="${{ matrix.kernel_flavor }}-${{ matrix.fedora_version }}"
 
           COMMIT_TAGS=()
           BUILD_TAGS=()
@@ -148,9 +142,9 @@ jobs:
         id: meta
         with:
           images: |
-            ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}
+            ${{ env.IMAGE_NAME) }}
           labels: |
-            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.title=${{ env.IMAGE_BASE_NAME }}
             org.opencontainers.image.description=A caching layer for pre-built akmod RPMs
             org.opencontainers.image.version=${{ env.SOURCE_IMAGE_VERSION }}
             ostree.linux=${{ env.SOURCE_IMAGE_LINUX }}
@@ -174,7 +168,7 @@ jobs:
         with:
           containerfiles: |
             ./Containerfile.${{ matrix.cfile_suffix }}
-          image: ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}
+          image: ${{ env.IMAGE_NAME) }}
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |
@@ -182,7 +176,6 @@ jobs:
             SOURCE_ORG=${{ env.SOURCE_ORG }}
             KERNEL_FLAVOR=${{ matrix.kernel_flavor }}
             FEDORA_MAJOR_VERSION=${{ matrix.fedora_version }}
-            NVIDIA_MAJOR_VERSION=${{ matrix.nvidia_version }}
             RPMFUSION_MIRROR=${{ vars.RPMFUSION_MIRROR }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -1,8 +1,8 @@
 ###
-### Containerfile.nvidia - used to build ONLY NVIDIA kmods (one driver version per build)
+### Containerfile.nvidia - used to build ONLY NVIDIA kmods
 ###
 
-#Build from base, simpley because it's the smallest image
+#Build from base, simply because it's the smallest image
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base}"
 ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}"
 ARG BASE_IMAGE="quay.io/${SOURCE_ORG}/${SOURCE_IMAGE}"
@@ -10,7 +10,6 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-39}"
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS builder
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-39}"
-ARG NVIDIA_MAJOR_VERSION="${NVIDIA_MAJOR_VERSION:-550}"
 ARG KERNEL_FLAVOR="{KERNEL_FLAVOR:-main}"
 ARG RPMFUSION_MIRROR=""
 
@@ -19,15 +18,9 @@ COPY certs /tmp/certs
 
 # files for nvidia
 COPY ublue-os-nvidia-addons.spec /tmp/ublue-os-nvidia-addons/ublue-os-nvidia-addons.spec
-ADD https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
-    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container-toolkit.repo
-ADD https://copr.fedorainfracloud.org/coprs/eyecantcu/supergfxctl/repo/fedora-${FEDORA_MAJOR_VERSION}/eyecantcu-supergfxctl-fedora-${FEDORA_MAJOR_VERSION}.repo \
-    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/eyecantcu-supergfxctl.repo
-ADD https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
-    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container.pp
-ADD files/etc/sway/environment /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/environment
-ADD files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/ublue-nvctk-cdi.service
-ADD files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
+COPY files/etc/sway/environment /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/environment
+COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/ublue-nvctk-cdi.service
+COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
 
 
 RUN /tmp/build-prep.sh
@@ -43,6 +36,7 @@ RUN if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
 
 RUN cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
       /var/cache/rpms/ublue-os/
+
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \
     done

--- a/build-ublue-os-nvidia-addons.sh
+++ b/build-ublue-os-nvidia-addons.sh
@@ -2,8 +2,19 @@
 
 set -oeux pipefail
 
+curl -L https://negativo17.org/repos/fedora-nvidia.repo \
+    -o /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/negativo17-fedora-nvidia.repo
 
+curl -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
+    -o /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container-toolkit.repo
 sed -i "s@gpgcheck=0@gpgcheck=1@" /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container-toolkit.repo
+
+curl -L https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
+    -o /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container.pp
+
+curl -L https://copr.fedorainfracloud.org/coprs/eyecantcu/supergfxctl/repo/fedora-${FEDORA_MAJOR_VERSION}/eyecantcu-supergfxctl-fedora-${FEDORA_MAJOR_VERSION}.repo \
+    -o /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/eyecantcu-supergfxctl.repo
+
 
 rpmbuild -ba \
     --define '_topdir /tmp/ublue-os-nvidia-addons/rpmbuild' \

--- a/ublue-os-nvidia-addons.spec
+++ b/ublue-os-nvidia-addons.spec
@@ -15,6 +15,7 @@ Source2:        nvidia-container.pp
 Source3:        environment
 Source4:        ublue-nvctk-cdi.service
 Source5:        70-ublue-nvctk-cdi.preset
+Source6:        negativo17-fedora-nvidia.repo
 
 %description
 Adds various runtime files for nvidia support.
@@ -24,6 +25,7 @@ Adds various runtime files for nvidia support.
 
 
 %build
+install -Dm0644 %{SOURCE6} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
 install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
@@ -31,17 +33,24 @@ install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/
 install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
 install -Dm0644 %{SOURCE5} %{buildroot}%{_presetdir}/70-ublue-nvctk-cdi.preset
 
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
+
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo        %{buildroot}%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service                          %{buildroot}%{_unitdir}/ublue-nvctk-cdi.service
 
 %files
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 %attr(0644,root,root) %{_datadir}/selinux/packages/nvidia-container.pp
@@ -49,6 +58,10 @@ install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.ser
 %attr(0644,root,root) %{_presetdir}/70-ublue-nvctk-cdi.preset
 
 %changelog
+* Sat Apr 13 Benjamin Sherman <benjamin@holyarmy.org> - 0.11
+- Add negativo17 fedora-nvidia repo for switch of NVIDIA driver source
+- Provided third-party repos are no longer enabled by default
+
 * Fri Oct 6 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.10
 - add ublue-nvctk-cdi service to auto-generate NVIDIA CDI GPU definitions
 


### PR DESCRIPTION
This reworks all the bits in akmods for nvidia:
- removes nvidia driver version as only latest is supported
- adds negativo17-fedora-nvidia repo to ublue-os-nvidia-addons RPM
- removes extra metadata from the nvidia-vars create in image

This PR will require a corresponding PR in hwe to ensure proper repos are being used and the new package names are installed since negativo17 has some different package naming.

This is a second attempt since the first was reverted: (see [#172](https://github.com/ublue-os/akmods/pull/172))